### PR TITLE
Add support for date/dateTime formats

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ deploy:
     artifact: /.*\.nupkg/
   - provider: NuGet
     api_key:
-      secure: bXIf2hY95Kmnjf3jaGG52gnjdloKMQH97hXDFOSQk/04Uk5fI47dN7A7BHbuHYKv
+      secure: 9vXzfqy1iC9lv9bMayd1OLHkRaaB370DMzyP2CUQtbkaUtdkOp1KLrruLisRXWV4
     on:
       appveyor_repo_tag: true 
     artifact: /.*\.nupkg/

--- a/src/DataDock.CsvWeb.Tests/CsvwTestCasesSpec.cs
+++ b/src/DataDock.CsvWeb.Tests/CsvwTestCasesSpec.cs
@@ -153,9 +153,7 @@ namespace DataDock.CsvWeb.Tests
             //var tableGroup = new TableGroup();
             //var table = new Table(tableGroup) {Url = new Uri(_baseUri, test.Action.Uri)};
             //await converter.ConvertAsync(tableGroup, new DefaultResolver());
-
-            converter.Errors.Should().BeEmpty("Expected no errors during conversion. Got:\n\t" +
-                                              string.Join("\n\t", converter.Errors));
+            converter.Errors.Should().BeEmpty("expected no errors during conversion");
             var differ = new GraphDiff();
             NormalizeLiterals(expect);
             NormalizeLiterals(actual);

--- a/src/DataDock.CsvWeb.Tests/DateFormatSpecificationSpec.cs
+++ b/src/DataDock.CsvWeb.Tests/DateFormatSpecificationSpec.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using DataDock.CsvWeb.Metadata;
+using FluentAssertions;
+using Xunit;
+
+namespace DataDock.CsvWeb.Tests
+{
+    public class DateFormatSpecificationSpec
+    {
+        [Theory]
+        [InlineData("yyyy-MM-dd", "2015-03-22", true, "2015-03-22")]
+        [InlineData("yyyyMMdd", "20150322", true, "2015-03-22")]
+        [InlineData("dd-MM-yyyy", "22-03-2015", true, "2015-03-22")]
+        [InlineData("d-M-yyyy", "22-3-2015", true, "2015-03-22")]
+        [InlineData("MM-dd-yyyy", "03-22-2015", true, "2015-03-22")]
+        [InlineData("M-d-yyyy", "3-22-2015", true, "2015-03-22")]
+        [InlineData("dd/MM/yyyy", "22/03/2015", true, "2015-03-22")]
+        [InlineData("d/M/yyyy", "22/3/2015", true, "2015-03-22")]
+        [InlineData("MM/dd/yyyy", "03/22/2015", true, "2015-03-22")]
+        [InlineData("M/d/yyyy", "3/22/2015", true, "2015-03-22")]
+        [InlineData("dd.MM.yyyy", "22.03.2015", true, "2015-03-22")]
+        [InlineData("d.M.yyyy", "22.3.2015", true, "2015-03-22")]
+        [InlineData("MM.dd.yyyy", "03.22.2015", true, "2015-03-22")]
+        [InlineData("M.d.yyyy", "3.22.2015", true, "2015-03-22")]
+        [InlineData("u-MM-dd", "2015-03-22", true, "2015-03-22")]
+        public void TestDateValidation(string formatString, string inputString, bool expectValid, string expectNormalized)
+        {
+            var formatSpec = new DateFormatSpecification(formatString);
+            formatSpec.IsValid(inputString).Should().Be(expectValid);
+            if (expectValid && expectNormalized != null)
+            {
+                formatSpec.Normalize(inputString).Should().Be(expectNormalized);
+            }
+        }
+    }
+}

--- a/src/DataDock.CsvWeb.Tests/DateTimeFormatSpecificationSpec.cs
+++ b/src/DataDock.CsvWeb.Tests/DateTimeFormatSpecificationSpec.cs
@@ -1,0 +1,63 @@
+﻿using DataDock.CsvWeb.Metadata;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace DataDock.CsvWeb.Tests
+{
+    public class DateTimeFormatSpecificationSpec
+    {
+        [Theory]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSS", "2015-03-15T15:02:37.143", true, "2015-03-15T15:02:37.143")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss", "2015-03-15T15:02:37", true, "2015-03-15T15:02:37")]
+        [InlineData("yyyy-MM-ddTHH:mm", "2015-03-15T15:02", true, "2015-03-15T15:02:00")]
+        [InlineData("dd-MM-yyyy HH:mm:ss.S", "15-03-2015 15:02:37.1", true, "2015-03-15T15:02:37.1")]
+        [InlineData("d/M/yyyy HH:mm:ss", "15/3/2015 15:02:37", true, "2015-03-15T15:02:37")]
+        [InlineData("M/d/yyyy HHmmss", "3/15/2015 150237", true, "2015-03-15T15:02:37")]
+        [InlineData("dd.MM.yyyy HH:mm", "15.03.2015 15:02",true, "2015-03-15T15:02:00")]
+        [InlineData("M.d.yyyy HHmm", "3.15.2015 1502", true, "2015-03-15T15:02:00")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSX", "2015-03-15T15:02:37.143Z", true, "2015-03-15T15:02:37.143Z")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSX", "2015-03-15T15:02:37.143-08", true, "2015-03-15T15:02:37.143-08")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSX", "2015-03-15T15:02:37.143+0530", true, "2015-03-15T15:02:37.143+05:30")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXX", "2015-03-15T15:02:37.143Z", true, "2015-03-15T15:02:37.143Z")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXX", "2015-03-15T15:02:37.143-08", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXX", "2015-03-15T15:02:37.143-0800", true, "2015-03-15T15:02:37.143-08")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXX", "2015-03-15T15:02:37.143+0530", true, "2015-03-15T15:02:37.143+05:30")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXXX", "2015-03-15T15:02:37.143Z", true, "2015-03-15T15:02:37.143Z")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXXX", "2015-03-15T15:02:37.143-08", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXXX", "2015-03-15T15:02:37.143-0800", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXXX", "2015-03-15T15:02:37.143+0530", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXXX", "2015-03-15T15:02:37.143-08:00", true, "2015-03-15T15:02:37.143-08")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSXXX", "2015-03-15T15:02:37.143+05:30", true, "2015-03-15T15:02:37.143+05:30")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSx", "2015-03-15T15:02:37.143Z", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSx", "2015-03-15T15:02:37.143+00", true, "2015-03-15T15:02:37.143Z")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSx", "2015-03-15T15:02:37.143-08", true, "2015-03-15T15:02:37.143-08")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSx", "2015-03-15T15:02:37.143+0530", true, "2015-03-15T15:02:37.143+05:30")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxx", "2015-03-15T15:02:37.143Z", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxx", "2015-03-15T15:02:37.143+0000", true, "2015-03-15T15:02:37.143Z")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxx", "2015-03-15T15:02:37.143-08", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxx", "2015-03-15T15:02:37.143-0800", true, "2015-03-15T15:02:37.143-08")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxx", "2015-03-15T15:02:37.143+0530", true, "2015-03-15T15:02:37.143+05:30")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143Z", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143+00:00", true, "2015-03-15T15:02:37.143Z")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143-08", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143-0800", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143+0530", false, null)]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143-08:00", true, "2015-03-15T15:02:37.143-08")]
+        [InlineData("yyyy-MM-ddTHH:mm:ss.SSSxxx", "2015-03-15T15:02:37.143+05:30", true, "2015-03-15T15:02:37.143+05:30")]
+        public void TestDateTimeValidation(string formatString, string inputString, bool expectValid,
+            string expectNormalized)
+        {
+            var formatSpec = new DateTimeFormatSpecification(formatString);
+            formatSpec.IsValid(inputString).Should().Be(expectValid);
+            if (expectValid)
+            {
+                formatSpec.Normalize(inputString).Should().Be(expectNormalized);
+            }
+            else
+            {
+                Assert.ThrowsAny<FormatException>(() => formatSpec.Normalize(inputString));
+            }
+        }
+    }
+}

--- a/src/DataDock.CsvWeb.Tests/TimeFormatSpecificationSpec.cs
+++ b/src/DataDock.CsvWeb.Tests/TimeFormatSpecificationSpec.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using DataDock.CsvWeb.Metadata;
+using FluentAssertions;
+using Xunit;
+
+namespace DataDock.CsvWeb.Tests
+{
+    public class TimeFormatSpecificationSpec
+    {
+        [Theory]
+        [InlineData("HH:mm:ss.SSS", "15:02:37.143", true, "15:02:37.143")]
+        [InlineData("HH:mm:ss", "15:02:37", true, "15:02:37")]
+        [InlineData("HH:mm", "15:02", true, "15:02:00")]
+        [InlineData("HH:mm:ss.S", "15:02:37.1", true, "15:02:37.1")]
+        [InlineData("HHmmss", "150237", true, "15:02:37")]
+        [InlineData("HHmm", "1502", true, "15:02:00")]
+        [InlineData("HH:mm:ss.SSSX", "15:02:37.143Z", true, "15:02:37.143Z")]
+        [InlineData("HH:mm:ss.SSSX", "15:02:37.143-08", true, "15:02:37.143-08")]
+        [InlineData("HH:mm:ss.SSSX", "15:02:37.143+0530", true, "15:02:37.143+05:30")]
+        [InlineData("HH:mm:ss.SSSXX", "15:02:37.143Z", true, "15:02:37.143Z")]
+        [InlineData("HH:mm:ss.SSSXX", "15:02:37.143-08", false, null)]
+        [InlineData("HH:mm:ss.SSSXX", "15:02:37.143-0800", true, "15:02:37.143-08")]
+        [InlineData("HH:mm:ss.SSSXX", "15:02:37.143+0530", true, "15:02:37.143+05:30")]
+        [InlineData("HH:mm:ss.SSSXXX", "15:02:37.143Z", true, "15:02:37.143Z")]
+        [InlineData("HH:mm:ss.SSSXXX", "15:02:37.143-08", false, null)]
+        [InlineData("HH:mm:ss.SSSXXX", "15:02:37.143-0800", false, null)]
+        [InlineData("HH:mm:ss.SSSXXX", "15:02:37.143+0530", false, null)]
+        [InlineData("HH:mm:ss.SSSXXX", "15:02:37.143-08:00", true, "15:02:37.143-08")]
+        [InlineData("HH:mm:ss.SSSXXX", "15:02:37.143+05:30", true, "15:02:37.143+05:30")]
+        [InlineData("HH:mm:ss.SSSx", "15:02:37.143Z", false, null)]
+        [InlineData("HH:mm:ss.SSSx", "15:02:37.143+00", true, "15:02:37.143Z")]
+        [InlineData("HH:mm:ss.SSSx", "15:02:37.143-08", true, "15:02:37.143-08")]
+        [InlineData("HH:mm:ss.SSSx", "15:02:37.143+0530", true, "15:02:37.143+05:30")]
+        [InlineData("HH:mm:ss.SSSxx", "15:02:37.143Z", false, null)]
+        [InlineData("HH:mm:ss.SSSxx", "15:02:37.143+0000", true, "15:02:37.143Z")]
+        [InlineData("HH:mm:ss.SSSxx", "15:02:37.143-08", false, null)]
+        [InlineData("HH:mm:ss.SSSxx", "15:02:37.143-0800", true, "15:02:37.143-08")]
+        [InlineData("HH:mm:ss.SSSxx", "15:02:37.143+0530", true, "15:02:37.143+05:30")]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143Z", false, null)]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143+00:00", true, "15:02:37.143Z")]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143-08", false, null)]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143-0800", false, null)]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143+0530", false, null)]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143-08:00", true, "15:02:37.143-08")]
+        [InlineData("HH:mm:ss.SSSxxx", "15:02:37.143+05:30", true, "15:02:37.143+05:30")]
+        public void TestDateTimeValidation(string formatString, string inputString, bool expectValid,
+            string expectNormalized)
+        {
+            var formatSpec = new TimeFormatSpecification(formatString);
+            formatSpec.IsValid(inputString).Should().Be(expectValid);
+            if (expectValid)
+            {
+                formatSpec.Normalize(inputString).Should().Be(expectNormalized);
+            }
+            else
+            {
+                Assert.ThrowsAny<FormatException>(() => formatSpec.Normalize(inputString));
+            }
+        }
+    }
+}

--- a/src/DataDock.CsvWeb/DataDock.CsvWeb.csproj
+++ b/src/DataDock.CsvWeb/DataDock.CsvWeb.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="CsvHelper" Version="12.2.3" />
     <PackageReference Include="dotNetRDF" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NodaTime" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/DataDock.CsvWeb/Metadata/DateFormatSpecification.cs
+++ b/src/DataDock.CsvWeb/Metadata/DateFormatSpecification.cs
@@ -1,27 +1,29 @@
 ﻿using System;
 using System.Globalization;
-using VDS.RDF.Parsing;
+using NodaTime.Text;
 
 namespace DataDock.CsvWeb.Metadata
 {
     public class DateFormatSpecification : IFormatSpecification
     {
-        private readonly string _format;
+        private readonly LocalDatePattern _pattern;
+        
         public DateFormatSpecification(string format)
         {
-            _format = format ?? throw new ArgumentNullException(nameof(format));
+            if (format == null) throw new ArgumentNullException(nameof(format));
+            _pattern = LocalDatePattern.CreateWithInvariantCulture(format);
         }
 
 
         public bool IsValid(string literal)
         {
-            return DateTime.TryParseExact(literal, _format, CultureInfo.InvariantCulture, DateTimeStyles.None,
-                out var result);
+            return _pattern.Parse(literal).Success;
         }
 
         public string Normalize(string literal)
         {
-            return DateTime.ParseExact(literal, _format, CultureInfo.InvariantCulture).ToString(XmlSpecsHelper.XmlSchemaDateFormat);
+            var parseResult = _pattern.Parse(literal);
+            return parseResult.GetValueOrThrow().ToString("R", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/DataDock.CsvWeb/Metadata/TimeFormatSpecification.cs
+++ b/src/DataDock.CsvWeb/Metadata/TimeFormatSpecification.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using NodaTime.Text;
+
+namespace DataDock.CsvWeb.Metadata
+{
+    public class TimeFormatSpecification : IFormatSpecification
+    {
+        private readonly bool _hasOffset;
+        private readonly LocalTimePattern _localPattern;
+        private readonly OffsetTimePattern _offsetPattern;
+
+        public TimeFormatSpecification(string format)
+        {
+            if (format == null) throw new ArgumentNullException(nameof(format));
+            _hasOffset = format.Contains("x") || format.Contains("X");
+            if (_hasOffset)
+            {
+                _offsetPattern = OffsetTimePattern.CreateWithInvariantCulture(GetNodaTimePattern(format));
+            }
+            else
+            {
+                _localPattern = LocalTimePattern.CreateWithInvariantCulture(GetNodaTimePattern(format));
+            }
+        }
+
+        internal static string GetNodaTimePattern(string unicodePattern)
+        {
+            return unicodePattern.Replace("S", "F")
+                .Replace("xxx", "o<m>")
+                .Replace("xx", "o<M>")
+                .Replace("x", "o<i>")
+                .Replace("XXX", "o<Z+HH:mm>")
+                .Replace("XX", "o<Z+HHmm>")
+                .Replace("X", "o<I>");
+        }
+
+        public bool IsValid(string literal)
+        {
+            return _hasOffset ? _offsetPattern.Parse(literal).Success : _localPattern.Parse(literal).Success;
+        }
+
+        public string Normalize(string literal)
+        {
+            return _hasOffset
+                ? OffsetTimePattern.ExtendedIso.Format(_offsetPattern.Parse(literal).GetValueOrThrow())
+                : LocalTimePattern.ExtendedIso.Format(_localPattern.Parse(literal).GetValueOrThrow());
+        }
+    }
+}

--- a/src/DataDock.CsvWeb/Parsing/JsonMetadataParser.cs
+++ b/src/DataDock.CsvWeb/Parsing/JsonMetadataParser.cs
@@ -619,6 +619,9 @@ namespace DataDock.CsvWeb.Parsing
                     case "date":
                         datatype.Format = new DateFormatSpecification(t.Value<string>());
                         break;
+                    case "time":
+                        datatype.Format = new TimeFormatSpecification(t.Value<string>());
+                        break;
                     case "datetime":
                         datatype.Format = new DateTimeFormatSpecification(t.Value<string>());
                         break;


### PR DESCRIPTION
- Replace use of base .NET Date/DateTime parsing with NodaTime which supports a more complete set of parsing options.
- Add tests for the basic date, time and dateTime format strings that are required by the CSVW spec
- Add TimeFormatSpecification for handling columns whose datatype is 'time'